### PR TITLE
Managing media blob urls

### DIFF
--- a/src/components/tracks/ControlPanel.jsx
+++ b/src/components/tracks/ControlPanel.jsx
@@ -10,10 +10,11 @@ const controlPanelStyle = {
   alignItems: 'center',
 };
 
-const ControlPanel = () => {
+const ControlPanel = (props) => {
+  const { addMediaBlobUrl } = props;
   return (
     <div style={controlPanelStyle}>
-      <Recorder />
+      <Recorder addMediaBlobUrl={addMediaBlobUrl} />
     </div>
   );
 };

--- a/src/components/tracks/CreateTrackContainer.jsx
+++ b/src/components/tracks/CreateTrackContainer.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ControlPanel from './ControlPanel';
 import { Colors } from '../../styles/colors';
 import PlayContainer from './PlayContainer';
@@ -10,10 +10,23 @@ const containerStyle = {
   flexFlow: 'column',
 };
 
-const CreateTrackContainer = ({title}) => {
+const CreateTrackContainer = ({ title }) => {
+  const [mediaBlobUrls, setMediaBlobUrls] = useState([]);
+
+  const addMediaBlobUrl = (newMediaBlobUrl) => {
+    setMediaBlobUrls((curMediaBlobUrls) => [
+      ...curMediaBlobUrls,
+      newMediaBlobUrl,
+    ]);
+  };
+
+  // Note: audio elements are included here for proof of concept only
   return (
     <div style={containerStyle}>
-      <ControlPanel />
+      {mediaBlobUrls.map((mediaBlobUrl, idx) => (
+        <audio src={mediaBlobUrl} key={idx} controls />
+      ))}
+      <ControlPanel addMediaBlobUrl={addMediaBlobUrl} />
       <div
         style={{
           color: Colors.white,
@@ -32,6 +45,6 @@ const CreateTrackContainer = ({title}) => {
 
 CreateTrackContainer.defaultProps = {
   title: 'Create Track',
-}
+};
 
 export default CreateTrackContainer;

--- a/src/components/tracks/Recorder.jsx
+++ b/src/components/tracks/Recorder.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { useReactMediaRecorder } from 'react-media-recorder';
 import RecordButton from './RecordButton';
 
-const Recorder = () => {
+const Recorder = (props) => {
+  const { addMediaBlobUrl } = props;
   const { status, startRecording, stopRecording } = useReactMediaRecorder({
     video: false,
     audio: true,
+    blobOptions: { type: 'audio/mpeg' },
+    onStop: (newMediaBlobUrl) => addMediaBlobUrl(newMediaBlobUrl),
   });
 
   return (


### PR DESCRIPTION
* Added state to CreateTrackContainer that manages the media blob URLs that have been recorded.
* For demonstration purposes, I included some code that will create audio controls for each individual audio blob you record.